### PR TITLE
Fix deviceAccess not going to 'pending' state if re-requesting media after a permissionDismissed error

### DIFF
--- a/index.js
+++ b/index.js
@@ -440,6 +440,7 @@ module.exports = State.extend({
             if (!self.permissionGranted  && !self.permissionBlocked) {
                 self.deviceAccess = 'pending';
             }
+            self.permissionTimeout = undefined;
         }, 100);
     },
 


### PR DESCRIPTION
Since we never actually clear the timeout variable, if you re-request media after the user hits the "x" in chrome, the deviceAccess state will never go back to "pending".
