### PR TITLE
dont use exact

### DIFF
--- a/index.js
+++ b/index.js
@@ -455,7 +455,7 @@ module.exports = State.extend({
                         sourceId: this.devices.preferredMicrophone
                     });
                 } else {
-                    constraints.audio.deviceId = { exact: this.devices.preferredMicrophone };
+                    constraints.audio.deviceId = this.devices.preferredMicrophone;
                 }
             }
         }
@@ -472,7 +472,7 @@ module.exports = State.extend({
                         sourceId: this.devices.preferredCamera
                     });
                 } else {
-                    constraints.video.deviceId = { exact: this.devices.preferredCamera };
+                    constraints.video.deviceId = this.devices.preferredCamera;
                 }
             }
         }


### PR DESCRIPTION
because the device may be gone. exact should not be used unless the existence of the device id is verified with enumerateDevices.
